### PR TITLE
Fix issue where variables content aren't found

### DIFF
--- a/templates/traefik.systemd.erb
+++ b/templates/traefik.systemd.erb
@@ -4,7 +4,7 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-ExecStart=/opt/<%= @package_name %>/<%= @package_name %> -c <%= @config_file_path %>
+ExecStart=/opt/<%= scope.lookupvar("traefik::package_name") %>/<%= scope.lookupvar("traefik::package_name") %> -c <%= scope.lookupvar("traefik::config_file_path") %>
 KillMode=process
 Restart=on-failure
 RestartSec=42s


### PR DESCRIPTION
Hi,

I got an issue using this module on a CentOS 7.3 instance, using default configuration, where the variables content are empty in the template .

In the Service paragraph, I get: 
```ExecStart=/opt// -c```

With my fix, I get : 
```ExecStart=/opt/traefik/traefik -c /etc/traefik/traefik.toml```

Hope this helps!
