### PR TITLE
Systemd unit file should not be executable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,7 @@
 class traefik::config {
   file { $traefik::init_path:
     content => template("traefik/traefik.${traefik::init_style}.erb"),
-    mode    => '0755',
+    mode    => '0644',
     require => File["/opt/${traefik::package_name}/${traefik::package_name}-${traefik::version}"],
   }
 


### PR DESCRIPTION
I noticed the following message in syslog when using the traefik puppet module:
`Configuration file /lib/systemd/system/traefik.service is marked executable. Please remove executable permission bits. Proceeding anyway.`

I've adjusted the file mode from 755 to 644 to fix this.